### PR TITLE
infra: remap frontend port to avoid gateway collision

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "80:80"
+      - "8081:80"
     depends_on:
       - backend
     networks:


### PR DESCRIPTION
- docker-compose.yml: frontend host port 80->8081 to avoid conflict with the Nginx gateway which owns port 80 on the cluster